### PR TITLE
Adopt samever caret ranges for zxcvbn dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
     "angular-mocks": "1.5.0"
   },
   "dependencies": {
-    "zxcvbn": "4.4.0",
+    "zxcvbn": "^4.4.1",
     "angular": "~1.5.0"
   }
 }


### PR DESCRIPTION
Adopt samever caret ranges for zxcvbn dependency to address issue: https://github.com/ghostbar/angular-zxcvbn/issues/23